### PR TITLE
New popup interface

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,6 +36,7 @@ WikiMirror.prototype.getModifiedUrl = function (actualUrlParts, domainIndex, stu
 };
 
 const allMirrors = [
+  new WikiMirror('wikipedia.org', 0),
   new WikiMirror('0wikipedia.org', 0),
   new WikiMirror('wikizero.com', 1),
   new WikiMirror('wikiwand.com', 1),

--- a/background.js
+++ b/background.js
@@ -46,6 +46,10 @@ function setSelectedMirror(selectedMirrorName) {
   [selectedMirror] = allMirrors.filter(mirror => mirror.name === selectedMirrorName);
 }
 
+function getAllMirrorsNames(){
+  return allMirrors.map((mirror) => mirror.name)
+}
+
 chrome.storage.local.get(selectedMirrorKey, (data) => {
   let selectedMirrorName = data[selectedMirrorKey];
   if (!selectedMirrorName) {

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,11 @@
     "scripts": ["background.js"]
   },
   "browser_action": {
-    "default_icon": "icons/zerowiki_icon_19.png",
+    "default_icon": {
+      "16": "icons/zerowiki_icon_16.png",
+      "48": "icons/zerowiki_icon_48.png",
+      "128": "icons/zerowiki_icon_128.png"
+    },
     "default_popup": "popup.html"
   },
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -10,7 +10,6 @@
     <style type="text/css">
       body {
         margin: 10px;
-        width: 280px;
         white-space: nowrap;
       }
 
@@ -18,15 +17,22 @@
         font-size: 15px;
       }
 
-      #container {
-        align-items: center;
-        display: flex;
-        justify-content: space-between;
+      span {
+        margin-bottom: 5px;
+      }
+
+      input {
+        margin-right: 10px;
       }
 
       #dropdown {
-        width: auto;
+        margin: 10px;
+        margin-left: 0px;
+        margin-right: 0px;
+        border-top: 1px solid #ddd;
+        padding-top: 10px;
       }
+
     </style>
 
     <!-- <script type="module" src="popup.js"></script> -->
@@ -37,7 +43,7 @@
     <h1>ZeroWiki</h1>
     <div id="container">
       <span>Choose a Wikipedia mirror:</span>
-      <select id="dropdown" />
+      <div id="dropdown"></div>
     </div>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -2,7 +2,9 @@
 
 const selectedMirrorKey = 'selectedMirror';
 
-const mirrorNames = ['0wikipedia.org', 'wikizero.com', 'wikiwand.com', 'wikipedi0.org'];
+const mirrorNames = chrome.extension.getBackgroundPage().getAllMirrorsNames()
+
+console.log(mirrorNames)
 
 function setSelectedMirror(mirrorName) {
   chrome.extension.getBackgroundPage().setSelectedMirror(mirrorName);

--- a/popup.js
+++ b/popup.js
@@ -23,7 +23,7 @@ chrome.storage.local.get(selectedMirrorKey, (data) => {
   dropdown.childNodes.forEach((mirrorOption) => {
     if (mirrorOption.value === selectedMirrorName) {
       // eslint-disable-next-line no-param-reassign
-      mirrorOption.selected = true;
+      mirrorOption.checked='checked';
     }
   });
   setSelectedMirror(selectedMirrorName);
@@ -34,23 +34,39 @@ document.addEventListener('DOMContentLoaded', () => {
   if (dropdown) {
     // $FlowFixMe
     mirrorNames.forEach((mirrorName) => {
-      const mirrorOption = document.createElement('option');
+      // <input type="radio" name="gender" value="male" checked> Male<br>
+      const mirrorOption = document.createElement('input');
+      mirrorOption.type = 'radio';
+      mirrorOption.name = 'wiki';
       mirrorOption.value = mirrorName;
-      mirrorOption.innerHTML = mirrorName;
+
+      const mirrorLabel = document.createElement('label');
+      mirrorLabel.innerHTML = mirrorName;
+
       dropdown.appendChild(mirrorOption);
+      dropdown.appendChild(mirrorLabel);
+      dropdown.appendChild(document.createElement('br'));
+
     });
 
     dropdown.addEventListener('change', () => {
-      selectedMirrorName = dropdown.value;
-      setSelectedMirror(selectedMirrorName);
-      // $FlowFixMe
-      const data = {};
-      data[selectedMirrorKey] = dropdown.value;
-      chrome.storage.local.set(data, () => {
-        if (chrome.runtime.error) {
-          console.log(chrome.runtime.error);
+
+      document.getElementsByName('wiki').forEach((radio)=> {
+
+        if(radio.checked) {
+
+          selectedMirrorName = radio.value;
+          setSelectedMirror(selectedMirrorName);
+          // $FlowFixMe
+          const data = {};
+          data[selectedMirrorKey] = radio.value;
+          chrome.storage.local.set(data, () => {
+            if (chrome.runtime.error) {
+              console.log(chrome.runtime.error);
+            }
+          });
         }
-      });
+      })
     });
   }
 });


### PR DESCRIPTION
Hello @halileohalilei 
I really like this little extension of yours.
In this PR I try to both solve #7 (by adding a self-reference wikipedia mirror) and provide a new and easier to navigate interface:

|Before|After|
|--|--|
|![final - interface - before](https://user-images.githubusercontent.com/6209647/42992942-5b3da578-8c0a-11e8-80c1-89798da07e81.png)|![final - interface - after](https://user-images.githubusercontent.com/6209647/42992941-5b18843c-8c0a-11e8-8d7d-729291b8b1e6.png)|

Also, I updated the way the action menu loads the icon, gaining a better look in my opinion:

|Before|After|
|--|--|
|![final - icon - before](https://user-images.githubusercontent.com/6209647/42992943-5b628b90-8c0a-11e8-92b7-5656147bd5c1.png)|![final - icon - after](https://user-images.githubusercontent.com/6209647/42992940-5af48eb0-8c0a-11e8-9582-648f9f536fa8.png)|

All screens have been taken on Firefox 60 on MacOS 10.13.4, but I tested the PR on Chrome too.
