### PR TITLE
Add New Proxies

### DIFF
--- a/background.js
+++ b/background.js
@@ -39,7 +39,6 @@ WikiMirror.prototype.getModifiedUrl = function (actualUrlParts, domainIndex, stu
 };
 
 const allMirrors = [
-  new WikiMirror('0wikipedia.org', 0),
   new WikiMirror('wikizero.com', 1),
   new WikiMirror('wikiwand.com', 1),
   new WikiMirror('wikipedi0.org', 0),

--- a/background.js
+++ b/background.js
@@ -42,6 +42,10 @@ const allMirrors = [
   new WikiMirror('wikizero.com', 1),
   new WikiMirror('wikiwand.com', 1),
   new WikiMirror('wikipedi0.org', 0),
+  new WikiMirror('00wikipedia.org', 0),
+  new WikiMirror('1wikipedia.org', 0),
+  new WikiMirror('2wikipedia.org', 0),
+  new WikiMirror('Zwikipedia.org', 0),
 ];
 
 function setSelectedMirror(selectedMirrorName) {


### PR DESCRIPTION
WikiZero announced they will migrate to a new domain due to some legal reasons.

> **Duyuru / Announcement**
> 
> Yakın bir zamanda hukuki sebeplerden dolayı 0wikipedia.org alan adı kapatılacaktır.
> Yeni alternatif alan adları ile devam edeceğiz.
> 00wikipedia.org / 1wikipedia.org / 2wikipedia.org / Zwikipedia.org
> 
> Örnek;
> https://tr.1wikipedia.org/wiki/Türkiye
> 
> Due to legal reasons, the domain name 0wikipedia.org will be closed.
> We will continue with new alternative domain names.
> 00wikipedia.org / 1wikipedia.org / 2wikipedia.org / Zwikipedia.org
> 
> Example;
> https://tr.1wikipedia.org/wiki/Türkiye

That's why I added new proxies/mirrors to `allMirrors`.

WikiZero did not announce any information about `wikizero.com`, `wikiwand.com` or `wikipedi0.org` so it is probably safer to keep them.

I couldn't exactly understand what is meant by `mirrorType` property of `WikiMirror` but if there's something wrong with the PR, I can change.

Also related to and closes #23.